### PR TITLE
docs: update README with support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # mongoolia
 
-> Keep your [mongoosejs](http://mongoosejs.com/) schemas synced with [Algolia](http://www.algolia.com)
+Keep your [Mongoose](http://mongoosejs.com/) schemas synced with [Algolia](http://www.algolia.com)
+
+> While this plugin was created by Algolia, it is not an officially supported API client. It is possible that future major versions of Mongoose break compatibility, or require changes.
 
 This plugin will automatically synchronise your models with an Algolia index every time a new document is added, updated or removed.
 


### PR DESCRIPTION
This adds an info note at the top of the README to let users know that Mongoolia isn't an officially supported API client. This reuses the note from the [Jekyll plugin](https://github.com/algolia/jekyll-algolia#readme).

I'm waiting for feedback from support to know what's the recommended way to get support when using the library.